### PR TITLE
Edit isCommand() method of BreakdownExpensesCommand 

### DIFF
--- a/logs/app.log
+++ b/logs/app.log
@@ -658,3 +658,109 @@ Nov 09, 2024 9:06:22 PM seedu.budgetbuddy.Storage load
 INFO: Data loaded successfully. Expenses: 0, Incomes: 0, Budgets: 0
 Nov 09, 2024 9:06:26 PM seedu.budgetbuddy.Storage save
 INFO: Saving data to file: ./data/BudgetBuddy.txt
+Nov 10, 2024 3:37:00 PM seedu.budgetbuddy.Storage <init>
+INFO: Storing ./data/BudgetBuddy.txt
+Nov 10, 2024 3:37:00 PM seedu.budgetbuddy.transaction.budget.BudgetManager getBudget
+INFO: No budget found for date: 2024-11
+Nov 10, 2024 3:37:00 PM seedu.budgetbuddy.transaction.budget.BudgetManager addBudget
+INFO: Added budget: Total Monthly Budget: 3200.0  Date: 2024-11  Category: {FOOD=200.0, ENTERTAINMENT=3000.0}
+Nov 10, 2024 3:37:00 PM seedu.budgetbuddy.transaction.budget.BudgetManager getBudget
+INFO: No budget found for date: 2024-10
+Nov 10, 2024 3:37:00 PM seedu.budgetbuddy.transaction.budget.BudgetManager addBudget
+INFO: Added budget: Total Monthly Budget: 2400.0  Date: 2024-10  Category: {TRANSPORT=1200.0, ENTERTAINMENT=1200.0}
+Nov 10, 2024 3:37:00 PM seedu.budgetbuddy.transaction.budget.BudgetManager getBudget
+INFO: No budget found for date: 2024-08
+Nov 10, 2024 3:37:00 PM seedu.budgetbuddy.transaction.budget.BudgetManager addBudget
+INFO: Added budget: Total Monthly Budget: 2550.0  Date: 2024-08  Category: {FOOD=750.0, OTHERS=1800.0}
+Nov 10, 2024 3:37:00 PM seedu.budgetbuddy.transaction.budget.BudgetManager getBudget
+INFO: No budget found for date: 2024-07
+Nov 10, 2024 3:37:00 PM seedu.budgetbuddy.transaction.budget.BudgetManager addBudget
+INFO: Added budget: Total Monthly Budget: 1700.0  Date: 2024-07  Category: {OTHERS=1700.0}
+Nov 10, 2024 3:37:00 PM seedu.budgetbuddy.transaction.budget.BudgetManager getBudget
+INFO: No budget found for date: 2024-05
+Nov 10, 2024 3:37:00 PM seedu.budgetbuddy.transaction.budget.BudgetManager addBudget
+INFO: Added budget: Total Monthly Budget: 3900.0  Date: 2024-05  Category: {FOOD=1300.0, ENTERTAINMENT=1300.0, OTHERS=1300.0}
+Nov 10, 2024 3:37:00 PM seedu.budgetbuddy.transaction.budget.BudgetManager getBudget
+INFO: No budget found for date: 2023-08
+Nov 10, 2024 3:37:00 PM seedu.budgetbuddy.transaction.budget.BudgetManager addBudget
+INFO: Added budget: Total Monthly Budget: 2600.0  Date: 2023-08  Category: {UTILITIES=700.0, OTHERS=1900.0}
+Nov 10, 2024 3:37:00 PM seedu.budgetbuddy.Storage load
+INFO: Data loaded successfully. Expenses: 0, Incomes: 0, Budgets: 0
+Nov 10, 2024 3:37:06 PM seedu.budgetbuddy.Storage save
+INFO: Saving data to file: ./data/BudgetBuddy.txt
+Nov 10, 2024 3:37:13 PM seedu.budgetbuddy.Storage save
+INFO: Saving data to file: ./data/BudgetBuddy.txt
+Nov 10, 2024 3:37:42 PM seedu.budgetbuddy.Storage save
+INFO: Saving data to file: ./data/BudgetBuddy.txt
+Nov 10, 2024 3:37:56 PM seedu.budgetbuddy.transaction.budget.RemainingBudgetManager createNewBudget
+INFO: Created new budget for 2024-02 with initial amount 0.0
+Nov 10, 2024 3:37:56 PM seedu.budgetbuddy.transaction.budget.RemainingBudgetManager <init>
+INFO: Deducted 12.0 from budget for 2024-02 in category FOOD
+Nov 10, 2024 3:37:56 PM seedu.budgetbuddy.transaction.budget.RemainingBudgetManager <init>
+INFO: Remaining budgets initialized and updated after deductions.
+Nov 10, 2024 3:37:56 PM seedu.budgetbuddy.transaction.budget.RemainingBudgetManager getRemainingBudgets
+INFO: Retrieved remaining budget for 2024-02 in category FOOD: -12.0
+Nov 10, 2024 3:37:56 PM seedu.budgetbuddy.transaction.budget.RemainingBudgetManager createNewBudget
+INFO: Created new budget for 2024-02 with initial amount 0.0
+Nov 10, 2024 3:37:56 PM seedu.budgetbuddy.transaction.budget.RemainingBudgetManager <init>
+INFO: Deducted 12.0 from budget for 2024-02 in category FOOD
+Nov 10, 2024 3:37:56 PM seedu.budgetbuddy.transaction.budget.RemainingBudgetManager <init>
+INFO: Remaining budgets initialized and updated after deductions.
+Nov 10, 2024 3:37:56 PM seedu.budgetbuddy.transaction.budget.RemainingBudgetManager getRemainingBudgets
+INFO: Retrieved remaining budget for 2024-02 in category FOOD: -12.0
+Nov 10, 2024 3:37:56 PM seedu.budgetbuddy.transaction.budget.RemainingBudgetManager createNewBudget
+INFO: Created new budget for 2024-02 with initial amount 0.0
+Nov 10, 2024 3:37:56 PM seedu.budgetbuddy.transaction.budget.RemainingBudgetManager <init>
+INFO: Deducted 12.0 from budget for 2024-02 in category FOOD
+Nov 10, 2024 3:37:56 PM seedu.budgetbuddy.transaction.budget.RemainingBudgetManager <init>
+INFO: Remaining budgets initialized and updated after deductions.
+Nov 10, 2024 3:37:56 PM seedu.budgetbuddy.transaction.budget.RemainingBudgetManager getRemainingBudgets
+INFO: Retrieved remaining budget for 2024-02 in category FOOD: -12.0
+Nov 10, 2024 3:37:56 PM seedu.budgetbuddy.transaction.budget.RemainingBudgetManager createNewBudget
+INFO: Created new budget for 2024-02 with initial amount 0.0
+Nov 10, 2024 3:37:56 PM seedu.budgetbuddy.transaction.budget.RemainingBudgetManager <init>
+INFO: Deducted 12.0 from budget for 2024-02 in category FOOD
+Nov 10, 2024 3:37:56 PM seedu.budgetbuddy.transaction.budget.RemainingBudgetManager <init>
+INFO: Remaining budgets initialized and updated after deductions.
+Nov 10, 2024 3:37:56 PM seedu.budgetbuddy.transaction.budget.RemainingBudgetManager getRemainingBudgets
+INFO: Retrieved remaining budget for 2024-02 in category FOOD: -12.0
+Nov 10, 2024 3:37:56 PM seedu.budgetbuddy.transaction.budget.RemainingBudgetManager createNewBudget
+INFO: Created new budget for 2024-02 with initial amount 0.0
+Nov 10, 2024 3:37:56 PM seedu.budgetbuddy.transaction.budget.RemainingBudgetManager <init>
+INFO: Deducted 12.0 from budget for 2024-02 in category FOOD
+Nov 10, 2024 3:37:56 PM seedu.budgetbuddy.transaction.budget.RemainingBudgetManager <init>
+INFO: Remaining budgets initialized and updated after deductions.
+Nov 10, 2024 3:37:56 PM seedu.budgetbuddy.transaction.budget.RemainingBudgetManager getRemainingBudgets
+INFO: Retrieved remaining budget for 2024-02 in category FOOD: -12.0
+Nov 10, 2024 3:38:25 PM seedu.budgetbuddy.Storage <init>
+INFO: Storing ./data/BudgetBuddy.txt
+Nov 10, 2024 3:38:25 PM seedu.budgetbuddy.transaction.budget.BudgetManager getBudget
+INFO: No budget found for date: 2024-11
+Nov 10, 2024 3:38:25 PM seedu.budgetbuddy.transaction.budget.BudgetManager addBudget
+INFO: Added budget: Total Monthly Budget: 3200.0  Date: 2024-11  Category: {FOOD=200.0, ENTERTAINMENT=3000.0}
+Nov 10, 2024 3:38:25 PM seedu.budgetbuddy.transaction.budget.BudgetManager getBudget
+INFO: No budget found for date: 2024-10
+Nov 10, 2024 3:38:25 PM seedu.budgetbuddy.transaction.budget.BudgetManager addBudget
+INFO: Added budget: Total Monthly Budget: 2400.0  Date: 2024-10  Category: {TRANSPORT=1200.0, ENTERTAINMENT=1200.0}
+Nov 10, 2024 3:38:25 PM seedu.budgetbuddy.transaction.budget.BudgetManager getBudget
+INFO: No budget found for date: 2024-08
+Nov 10, 2024 3:38:25 PM seedu.budgetbuddy.transaction.budget.BudgetManager addBudget
+INFO: Added budget: Total Monthly Budget: 2550.0  Date: 2024-08  Category: {FOOD=750.0, OTHERS=1800.0}
+Nov 10, 2024 3:38:25 PM seedu.budgetbuddy.transaction.budget.BudgetManager getBudget
+INFO: No budget found for date: 2024-07
+Nov 10, 2024 3:38:25 PM seedu.budgetbuddy.transaction.budget.BudgetManager addBudget
+INFO: Added budget: Total Monthly Budget: 1700.0  Date: 2024-07  Category: {OTHERS=1700.0}
+Nov 10, 2024 3:38:25 PM seedu.budgetbuddy.transaction.budget.BudgetManager getBudget
+INFO: No budget found for date: 2024-05
+Nov 10, 2024 3:38:25 PM seedu.budgetbuddy.transaction.budget.BudgetManager addBudget
+INFO: Added budget: Total Monthly Budget: 3900.0  Date: 2024-05  Category: {FOOD=1300.0, ENTERTAINMENT=1300.0, OTHERS=1300.0}
+Nov 10, 2024 3:38:25 PM seedu.budgetbuddy.transaction.budget.BudgetManager getBudget
+INFO: No budget found for date: 2023-08
+Nov 10, 2024 3:38:25 PM seedu.budgetbuddy.transaction.budget.BudgetManager addBudget
+INFO: Added budget: Total Monthly Budget: 2600.0  Date: 2023-08  Category: {UTILITIES=700.0, OTHERS=1900.0}
+Nov 10, 2024 3:38:25 PM seedu.budgetbuddy.Storage load
+INFO: Data loaded successfully. Expenses: 0, Incomes: 0, Budgets: 0
+Nov 10, 2024 3:38:35 PM seedu.budgetbuddy.Storage save
+INFO: Saving data to file: ./data/BudgetBuddy.txt
+Nov 10, 2024 3:38:38 PM seedu.budgetbuddy.Storage save
+INFO: Saving data to file: ./data/BudgetBuddy.txt

--- a/src/main/java/seedu/budgetbuddy/commands/expense/BreakdownExpensesCommand.java
+++ b/src/main/java/seedu/budgetbuddy/commands/expense/BreakdownExpensesCommand.java
@@ -15,7 +15,7 @@ public class BreakdownExpensesCommand extends Command {
      * @return true if command starts with "breakdown expenses", false otherwise.
      */
     public static boolean isCommand(String command){
-        return command.startsWith("breakdown expenses");
+        return command.equals("breakdown expenses");
     }
 
     /**


### PR DESCRIPTION
Validate commands equals to "breakdown expenses" instead of those starting with "breakdown expenses". 
Fixes #196 